### PR TITLE
Add URLs for python wheels used in the spec file; set $GET_FILES=true…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: required
 env:
   - REPO_NAME=${TRAVIS_REPO_SLUG#*/}
+    GET_FILES=true
 
 git:
   depth: false
@@ -17,7 +18,5 @@ before_install:
   - sudo docker pull opensciencegrid/osg-build
 
 script:
-  - mkdir upstream
-  - wget https://vdt.cs.wisc.edu/upstream/xcache/1.3.0/python-deps/numpy-1.16.6-cp27-cp27mu-manylinux1_x86_64.whl -O upstream/numpy-1.16.6-cp27-cp27mu-manylinux1_x86_64.whl
-  - docker run -v $(pwd):/$REPO_NAME -e REPO_NAME=$REPO_NAME --cap-add=SYS_ADMIN opensciencegrid/osg-build build-from-github
+  - docker run -v $(pwd):/$REPO_NAME -e REPO_NAME=$REPO_NAME -e GET_FILES=$GET_FILES --cap-add=SYS_ADMIN opensciencegrid/osg-build build-from-github
 

--- a/rpm/xcache.spec
+++ b/rpm/xcache.spec
@@ -6,14 +6,14 @@ License:   Apache 2.0
 Group:     Grid
 URL:       https://opensciencegrid.org/docs/
 Source0:   %{name}-%{version}.tar.gz
-Source1:   numpy-1.16.6-cp27-cp27mu-manylinux1_x86_64.whl
-Source2:   cachetools-3.1.1-py2.py3-none-any.whl
-Source3:   awkward-0.12.20-py2.py3-none-any.whl
-Source4:   uproot_methods-0.7.3-py2.py3-none-any.whl
-Source5:   uproot-3.11.2-py2.py3-none-any.whl
-Source6:   xxhash-1.4.3-cp27-cp27mu-manylinux1_x86_64.whl
-Source7:   lz4-2.2.1-cp27-cp27mu-manylinux1_x86_64.whl
-Source8:   pyliblzma-0.5.3.tar.bz2
+Source1:   https://vdt.cs.wisc.edu/upstream/xcache/1.3.0/python-deps/numpy-1.16.6-cp27-cp27mu-manylinux1_x86_64.whl
+Source2:   https://vdt.cs.wisc.edu/upstream/xcache/1.3.0/python-deps/cachetools-3.1.1-py2.py3-none-any.whl
+Source3:   https://vdt.cs.wisc.edu/upstream/xcache/1.3.0/python-deps/awkward-0.12.20-py2.py3-none-any.whl
+Source4:   https://vdt.cs.wisc.edu/upstream/xcache/1.3.0/python-deps/uproot_methods-0.7.3-py2.py3-none-any.whl
+Source5:   https://vdt.cs.wisc.edu/upstream/xcache/1.3.0/python-deps/uproot-3.11.2-py2.py3-none-any.whl
+Source6:   https://vdt.cs.wisc.edu/upstream/xcache/1.3.0/python-deps/xxhash-1.4.3-cp27-cp27mu-manylinux1_x86_64.whl
+Source7:   https://vdt.cs.wisc.edu/upstream/xcache/1.3.0/python-deps/lz4-2.2.1-cp27-cp27mu-manylinux1_x86_64.whl
+Source8:   https://vdt.cs.wisc.edu/upstream/xcache/1.3.0/python-deps/pyliblzma-0.5.3.tar.bz2
 
 
 BuildRequires: systemd


### PR DESCRIPTION
… in the travis tests so build-from-github will download the files

I ended up adding a feature to the build-from-github script in the osg-build docker container: https://github.com/opensciencegrid/docker-osg-build/commit/e6ab1fa59f9124002d79246ae9faa5196a17ce51

Basically, sources can be specified as URLs in spec files. By default they do not get downloaded automatically but there is a tool called spectool that will go through and download them if they're missing.

This does _not_ affect your Koji builds: you will still need to create .source files in SVN for these files.